### PR TITLE
Database: implement rusqlite and primary create database function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock
 
 /target
 /Cargo.lock
+
+# vim swap files
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ path = "src/ospl.rs"
 
 
 [dependencies]
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 rand = "0.8.5"
 

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS `settings` (
+	`name`	TEXT NOT NULL UNIQUE,
+	`value`	TEXT,
+	PRIMARY KEY(`name`)
+);
+CREATE TABLE IF NOT EXISTS `photos` (
+	`id`				INTEGER NOT NULL UNIQUE,
+	`hash`				TEXT NOT NULL,
+	`original_name`		TEXT NOT NULL,
+	`new_name`			TEXT NOT NULL,
+	`import_datetime`	TEXT,
+	`random`			TEXT,
+	`import_year`		INTEGER,
+	`import_month`		INTEGER,
+	`import_day`		INTEGER,
+	`import_hour`		INTEGER,
+	`import_minute`		INTEGER,
+	`import_second`		INTEGER,
+	`exif_height`		INTEGER,
+	`exif_width`		INTEGER ,
+	`exif_time`			TEXT,
+	`exif_brand`		TEXT,
+	`exif_peripheral`	TEXT,
+	`fav`				INTEGER DEFAULT 0,
+	PRIMARY KEY(`id` AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS `includes` (
+	`including_folder`	INTEGER,
+	`included_folder`	INTEGER,
+	FOREIGN KEY(`including_folder`) REFERENCES `folders`(`id`),
+	FOREIGN KEY(`included_folder`) REFERENCES `folders`(`id`),
+	PRIMARY KEY(`including_folder`,`included_folder`)
+);
+CREATE TABLE IF NOT EXISTS `holds` (
+	`held_folder`	INTEGER,
+	`holded_album`		INTEGER,
+	FOREIGN KEY(`holded_album`) REFERENCES `albums`(`id`),
+	FOREIGN KEY(`held_folder`) REFERENCES `folders`(`id`),
+	PRIMARY KEY(`held_folder`,`holded_album`)
+);
+CREATE TABLE IF NOT EXISTS `folders` (
+	`id`	INTEGER NOT NULL UNIQUE,
+	`name`	INTEGER,
+	PRIMARY KEY(`id` AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS `contains` (
+	`containing_album`	INTEGER,
+	`contained_photo`	INTEGER,
+	FOREIGN KEY(`contained_photo`) REFERENCES `photos`(`id`),
+	FOREIGN KEY(`containing_album`) REFERENCES `albums`(`id`),
+	PRIMARY KEY(`containing_album`,`contained_photo`)
+);
+CREATE TABLE IF NOT EXISTS `albums` (
+	`id`	INTEGER NOT NULL UNIQUE,
+	`name`	TEXT,
+	PRIMARY KEY(`id` AUTOINCREMENT)
+);
+

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,9 @@
 use super::DATABASE_FILENAME;
 
+use rusqlite::{Connection};
+
+static DATABASE_SQL: &str = include_str!("../database.sql");
+
 pub struct Database
 {
 	pub path: String
@@ -9,6 +13,12 @@ impl Database
 {
 	pub fn create(path: &String) -> Self
 	{
+		let connection = Connection::open(path.clone() + "/" + DATABASE_FILENAME).unwrap();
+		match connection.execute_batch(DATABASE_SQL)
+		{
+			Ok(_) => println!("success!"),
+			Err(e) => println!("error creating db: {:?}", e),
+		};
 		Database
 		{
 			path: path.clone() + DATABASE_FILENAME,

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,5 @@
 use super::DATABASE_FILENAME;
+use super::Error;
 
 use rusqlite::{Connection};
 
@@ -11,17 +12,24 @@ pub struct Database
 
 impl Database
 {
-	pub fn create(path: &String) -> Self
+	pub fn create(path: &String) -> Result<Self, Error>
 	{
-		let connection = Connection::open(path.clone() + "/" + DATABASE_FILENAME).unwrap();
-		match connection.execute_batch(DATABASE_SQL)
+		let connection = match Connection::open(path.clone() + "/" + DATABASE_FILENAME)
 		{
-			Ok(_) => println!("success!"),
-			Err(e) => println!("error creating db: {:?}", e),
+			Ok(c) => Ok(c),
+			Err(why) => return Err(Error::Other)
 		};
-		Database
+		
+		match connection?.execute_batch(DATABASE_SQL)
 		{
-			path: path.clone() + DATABASE_FILENAME,
+			Ok(_) =>
+			{
+				return Ok(Database
+				{
+					path: path.clone() + DATABASE_FILENAME,
+				})
+			},
+			Err(why) => return Err(Error::Other)
 		}
 	}
 }

--- a/src/ospl.rs
+++ b/src/ospl.rs
@@ -41,7 +41,14 @@ impl Library
 				Some(Library
 				{
 					path: path.clone(),
-					db: Database::create(&path),
+					db:
+					{
+						match Database::create(&path)
+						{
+							Ok(db) => db,
+							Err(e) => return None
+						}
+					},
 				})
 			},
 			Err(n) => {println!("{:?}", n); None},
@@ -135,5 +142,17 @@ mod tests
 		assert!(check_table_presence("contains", &db_path));
 		assert!(check_table_presence("albums", &db_path));
 		remove_test_path(path);
+	}
+
+	#[test]
+	#[should_panic]
+	fn create_library_no_permissions()
+	{
+		let _library = match Library::create(&"/".to_string())
+		{
+			Some(_) => println!("trying to create library at path '/' should not return Some()"),
+			None => {panic!("could not create library at path '/'")}
+		};
+
 	}
 }


### PR DESCRIPTION
New dependency:
- `rusqlite`: the sqlite wrapper

New file:
- `database.sql`: containing the create table for the sqlite database

Function return of `Database::Create` is now a `Result<>` to handle errors.

New tests:
- Testing if the `database.db` file is created
- Testing if all the tables are present in the database.