### PR TITLE
hash: add hash algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 rand = "0.8.5"
 infer = "0.11.0"
 
+[dependencies.xxhash-rust]
+version = "0.8.6"
+features = ["xxh3"]

--- a/database.sql
+++ b/database.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS settings (
 CREATE TABLE IF NOT EXISTS photos (
 	id						INTEGER NOT NULL UNIQUE,
 	filename				TEXT NOT NULL UNIQUE,
-	hash					TEXT NOT NULL,
+	hash					BLOB NOT NULL,
 	thumbnail_hash			TEXT,
 	import_datetime			DATETIME,
 	-- Image information

--- a/src/photo.rs
+++ b/src/photo.rs
@@ -20,9 +20,11 @@
 
 use crate::element::ElementDatabase;
 use crate::Database;
-
+use crate::Error;
 use crate::utility;
-use super::Error;
+
+use xxhash_rust::xxh3::xxh3_128;
+
 use std::path::Path;
 
 /// Structure containing a replica of sqlite data
@@ -32,7 +34,7 @@ pub struct Photo
 {
 	id:					u32,
 	filename:			String,
-	hash:				String,
+	hash:				u128,
 	import_datetime:	String,
 	rating:				u32,
 	starred:			bool,
@@ -47,7 +49,7 @@ impl Photo
 		{
 			id:					0,
 			filename:			String::from(""),
-			hash:				String::from(""),
+			hash:				0,
 			import_datetime:	String::from(""),
 			rating:				0,
 			starred:			false,
@@ -69,7 +71,7 @@ impl Photo
 			return Err(Error::NotAnImage);
 		}
 		self.filename = get_filename_from(photo_path);
-		//TODO: fill hash using a fast hash algorithm like xxHash
+		self.hash = xxh3_128(&std::fs::read(photo_path).unwrap());
 		println!("file: {:#?}", &self);
 		Ok(())
 	}


### PR DESCRIPTION
using xx3 hash with it 128 bit version to hash photos. it is the more portable and the fastest algorithm available for now.

ospl will need to store it as a blob into the database to avoid doing conversions into String.