### PR TITLE
database refactoring into multiple connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.8.5"
 infer = "0.11.0"
 chrono = "0.4.23"
 image = "0.24.5"
+log = "0.4.17"
 
 [dependencies.xxhash-rust]
 version = "0.8.6"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -65,12 +65,12 @@ impl Collection
 		}
 	}
 
-	pub fn get_name (&self) -> String
+	pub fn name (&self) -> String
 	{
 		self.name.clone()
 	}
 	
-	pub fn get_comment (&self) -> String
+	pub fn comment (&self) -> String
 	{
 		self.comment.clone()
 	}

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -125,7 +125,7 @@ impl ElementFilesystem for Collection
 {
 	fn insert_into (&self, fs: &Filesystem) -> Result<(), Error> 
 	{
-		let path = fs.get_collections_path().join(&self.name);
+		let path = fs.collections_path().join(&self.name);
 		std::fs::create_dir(&path)?;
 		Ok(())
 	}

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -27,6 +27,7 @@ use crate::Error;
 use chrono::naive::NaiveDateTime;
 
 /// Structure containing a replica of sqlite data
+#[derive(Debug)]
 pub struct Collection
 {
 	pub id:					u32,

--- a/src/database.rs
+++ b/src/database.rs
@@ -27,6 +27,7 @@ use rusqlite::{Connection};
 static DATABASE_SQL: &str = include_str!("../database.sql");
 
 /// The database structure manages the connection to the db and every db entry.
+#[derive(Debug)]
 pub struct Database
 {
 	pub connection: Connection,

--- a/src/database.rs
+++ b/src/database.rs
@@ -17,11 +17,11 @@
 	with this program; if not, write to the Free Software Foundation, Inc.,
 	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-use super::DATABASE_FILENAME;
+
 use super::Error;
 use crate::element::ElementDatabase;
 
-use std::path::{Path, PathBuf};
+use std::path::{Path};
 use rusqlite::{Connection};
 
 static DATABASE_SQL: &str = include_str!("../database.sql");
@@ -29,7 +29,6 @@ static DATABASE_SQL: &str = include_str!("../database.sql");
 /// The database structure manages the connection to the db and every db entry.
 pub struct Database
 {
-	pub path: PathBuf,
 	pub connection: Connection,
 }
 
@@ -38,17 +37,16 @@ impl Database
 	/// Creates a database object, and returns it with a open connection
 	pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error>
 	{
-		match Connection::open(path.as_ref().join(DATABASE_FILENAME))
+		match Connection::open(path.as_ref())
 		{
 			Ok(c) =>
 			{
 				return Ok(Database
 				   {
-						path: path.as_ref().join(DATABASE_FILENAME),
 						connection: c,
 				   });
 			}
-			Err(_why) => return Err(Error::Other)
+			Err(why) => {log::warn!("error: {}", why); return Err(Error::Other)}
 		};
 	}
 
@@ -59,7 +57,7 @@ impl Database
 		match db.connection.execute_batch(DATABASE_SQL)
 		{
 			Ok(_) => { return Ok(db); },
-			Err(_why) => return Err(Error::Other)
+			Err(why) => { log::warn!("error: {}", why); return Err(Error::Other) }
 		}
 	}
 }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 use std::os::unix::fs::PermissionsExt;
 
 /// This structure will be removed do not use
+#[derive(Debug)]
 pub(crate) struct Directory
 {
 	path: PathBuf

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -28,6 +28,7 @@ use super::DATABASE_FILENAME;
 use std::path::{Path, PathBuf};
 
 /// The Filesystem structure manages every file and directory in the library.
+#[derive(Debug)]
 pub struct Filesystem
 {
 	root_path: PathBuf,

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -20,17 +20,21 @@
 
 use crate::Directory;
 use crate::Error;
+use crate::database::Database;
 use crate::element::ElementFilesystem;
+
+use super::DATABASE_FILENAME;
 
 use std::path::{Path, PathBuf};
 
 /// The Filesystem structure manages every file and directory in the library.
 pub struct Filesystem
 {
-	pub path: PathBuf,
+	root_path: PathBuf,
 	pictures_path: PathBuf,
 	thumbnails_path: PathBuf,
 	collections_path: PathBuf,
+	database_path:	PathBuf,
 }
 
 impl Filesystem
@@ -40,10 +44,11 @@ impl Filesystem
 	{
 		return Ok(Filesystem
 			{
-				path: path.as_ref().to_path_buf(),
+				root_path: path.as_ref().to_path_buf(),
 				thumbnails_path: path.as_ref().join("thumbnails"),
 				pictures_path: path.as_ref().join("pictures"),
 				collections_path: path.as_ref().join("collections"),
+				database_path: path.as_ref().join(DATABASE_FILENAME),
 			});
 	}
 
@@ -51,18 +56,22 @@ impl Filesystem
 	pub(crate) fn create<P: AsRef<Path>>(path: P) -> Result<Self, Error>
 	{
 		let fs = Self::new(path)?;
-
 		Directory::from(&fs.thumbnails_path)?.create()?;
 		Directory::from(&fs.pictures_path)?.create()?;
 		Directory::from(&fs.collections_path)?.create()?;
+		Database::create(&fs.database_path)?;
 		Ok(fs)
 	}
-
-
 }
 
 impl Filesystem
 {
+	/// Returns the path on filesystem of the library folder
+	pub fn root_path(&self) -> PathBuf
+	{
+		self.root_path.clone()
+	}
+
 	/// Returns the path on filesystem to the pictures path in the library
 	pub fn pictures_path(&self) -> PathBuf
 	{
@@ -79,6 +88,12 @@ impl Filesystem
 	pub fn collections_path(&self) -> PathBuf
 	{
 		self.collections_path.to_path_buf()
+	}
+
+	/// Returns the path on filesystem of the database file
+	pub fn database_path(&self) -> PathBuf
+	{
+		self.database_path.clone()
 	}
 }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -64,19 +64,19 @@ impl Filesystem
 impl Filesystem
 {
 	/// Returns the path on filesystem to the pictures path in the library
-	pub fn get_pictures_path(&self) -> PathBuf
+	pub fn pictures_path(&self) -> PathBuf
 	{
 		self.pictures_path.to_path_buf()
 	}
 
 	/// Returns the path on filesystem to the thumbnails path in the library
-	pub fn get_thumbnails_path(&self) -> PathBuf
+	pub fn thumbnails_path(&self) -> PathBuf
 	{
 		self.thumbnails_path.to_path_buf()
 	}
 
 	/// Returns the path on filesystem to the collections path in the library
-	pub fn get_collections_path(&self) -> PathBuf
+	pub fn collections_path(&self) -> PathBuf
 	{
 		self.collections_path.to_path_buf()
 	}

--- a/src/ospl.rs
+++ b/src/ospl.rs
@@ -49,7 +49,6 @@ use directory::Directory;
 use photo::Photo;
 use collection::Collection;
 
-
 #[derive(Debug, PartialEq)]
 pub enum Error
 {
@@ -123,7 +122,7 @@ impl From<image::ImageError> for Error
 		}
 	}
 }
-
+#[derive(Debug)]
 pub struct Library
 {
 	fs: Filesystem,

--- a/src/ospl.rs
+++ b/src/ospl.rs
@@ -183,7 +183,7 @@ impl Library
 		photo.from_file(&self.db, &photo_path)?;
 		let id = self.db.insert(&photo)?;
 		self.fs.insert(&photo)?;
-		thumbnails::create_thumbnail_from_path(photo_path, self.fs.get_thumbnails_path().join(photo.get_filename()))?;
+		thumbnails::create_thumbnail_from_path(photo_path, self.fs.thumbnails_path().join(photo.get_filename()))?;
 		Ok(id)
 	}
 

--- a/src/ospl.rs
+++ b/src/ospl.rs
@@ -250,8 +250,8 @@ impl Library
 	///	let library = Library::create(&"/my/awesome/path.ospl/".to_string()).unwrap();
 	///	library.create_collection("2019", "Photos from 2019").unwrap();
 	/// let collection = library.get_collection_from_id(1).unwrap();
-	/// assert_eq!("2019", collection.get_name());
-	/// assert_eq!("Photos from 2019", collection.get_comment());
+	/// assert_eq!("2019", collection.name());
+	/// assert_eq!("Photos from 2019", collection.comment());
 	/// assert_eq!(1, collection.id);
 	///```
 	pub fn get_collection_from_id(&self, id: u32) -> Result<Collection, Error>

--- a/src/photo.rs
+++ b/src/photo.rs
@@ -152,7 +152,7 @@ impl ElementFilesystem for Photo
 	/// Inserts a photo into the filesystem using `self.path_on_fs` variable
 	fn insert_into(&self, fs: &Filesystem) -> Result<(), Error>
 	{
-		std::fs::copy(&self.path_on_fs, fs.get_pictures_path().join(self.get_filename()))?;
+		std::fs::copy(&self.path_on_fs, fs.pictures_path().join(self.get_filename()))?;
 		Ok(())
 	}
 
@@ -161,8 +161,8 @@ impl ElementFilesystem for Photo
 	/// this includes the thumbnail, and in the future every reference to it in the albums
 	fn remove_from(&self, fs: &Filesystem) -> Result<(), Error>
 	{
-		std::fs::remove_file(fs.get_pictures_path().join(self.get_filename()))?;
-		std::fs::remove_file(fs.get_thumbnails_path().join(self.get_filename()))?;
+		std::fs::remove_file(fs.pictures_path().join(self.get_filename()))?;
+		std::fs::remove_file(fs.thumbnails_path().join(self.get_filename()))?;
 		Ok(())
 	}
 }

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -1,53 +1,29 @@
+mod library_tests;
+use library_tests::generate_test_path;
+use library_tests::remove_test_path;
 
 #[cfg(test)]
 mod tests
 {
 	use ospl::Library;
-	use ospl::LIBRARY_EXTENSION;
 	use ospl::Error;
-
-	use rand::{thread_rng, Rng};
-	use rand::distributions::Alphanumeric;
-
-	static TEST_DIR: &str = env!("CARGO_TARGET_TMPDIR");
-
-	fn remove_test_path(path: String)
-	{
-		println!("removing test dir");
-		match std::fs::remove_dir_all(path)
-		{
-			Ok(_) => {},
-			Err(e) => {println!("{:?}", e)}
-		}
-	}
-
-	fn generate_test_path() -> String
-	{
-		let rand_string: String = thread_rng()
-			.sample_iter(&Alphanumeric)
-			.take(30)
-			.map(char::from)
-			.collect();
-		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
-	}
-
 
 	#[test]
 	fn create_collection()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		match library.create_collection("2019", "Photos from 2019") {
 			Ok(_) => {},
 			Err(err) => {panic!("Error creating collection: {:?}", err)}
 		};
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn get_id_not_exist()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		match library.get_collection_from_id(1)
@@ -61,13 +37,13 @@ mod tests
 			}
 			Ok(_) => panic!("error: should not return Ok() with an unexisting id")
 		}
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn create_collection_test_values()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		let name = "2019";
@@ -77,6 +53,6 @@ mod tests
 		assert_eq!(name, collection.name());
 		assert_eq!(comment, collection.comment());
 
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 }

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -28,7 +28,7 @@ mod tests
 			.take(30)
 			.map(char::from)
 			.collect();
-		TEST_DIR.to_string() + &rand_string + &LIBRARY_EXTENSION.to_string()
+		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
 	}
 
 

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -74,8 +74,8 @@ mod tests
 		let comment = "Photos from 2019";
 		library.create_collection(name, comment).unwrap();
 		let collection = library.get_collection_from_id(1).unwrap();
-		assert_eq!(name, collection.get_name());
-		assert_eq!(comment, collection.get_comment());
+		assert_eq!(name, collection.name());
+		assert_eq!(comment, collection.comment());
 
 		remove_test_path(path);
 	}

--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -1,44 +1,17 @@
+mod library_tests;
+use library_tests::generate_test_path;
+use library_tests::remove_test_path;
 
 #[cfg(test)]
 mod tests
 {
 	use ospl::Library;
-	use ospl::LIBRARY_EXTENSION;
 	use ospl::Error;
-	//use ospl::photo::Photo;
-
-	//use std::fs;
-	use rand::{thread_rng, Rng};
-	use rand::distributions::Alphanumeric;
-
-	//use rusqlite::{Connection};
-
-	static TEST_DIR: &str = env!("CARGO_TARGET_TMPDIR");
-
-	fn remove_test_path(path: String)
-	{
-		println!("removing test dir");
-		match std::fs::remove_dir_all(path)
-		{
-			Ok(_) => {},
-			Err(e) => {println!("{:?}", e)}
-		}
-	}
-
-	fn generate_test_path() -> String
-	{
-		let rand_string: String = thread_rng()
-			.sample_iter(&Alphanumeric)
-			.take(30)
-			.map(char::from)
-			.collect();
-		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
-	}
 
 	#[test]
 	fn import_and_get()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		match library.import_photo("tests/files/test_photo_light.jpg")
@@ -58,13 +31,13 @@ mod tests
 			},
 			Err(e) => panic!("error: importing not possible: {:?}", e)
 		}
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn get_id_not_exist()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		println!("{:#?}", library.get_photo_from_id(10));
@@ -79,24 +52,24 @@ mod tests
 			}
 			Ok(_) => panic!("error: should not return Ok() with an unexisting id")
 		}
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn delete_imported_photo()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		library.import_photo("tests/files/test_photo_light.jpg").unwrap();
 		library.delete_photo_by_id(1).unwrap();
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn delete_not_imported_photo()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		match library.delete_photo_by_id(1)
@@ -110,7 +83,7 @@ mod tests
 			}
 			Ok(_) => panic!("error: should not return Ok() with an unexisting id")
 		}
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 }

--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -32,7 +32,7 @@ mod tests
 			.take(30)
 			.map(char::from)
 			.collect();
-		TEST_DIR.to_string() + &rand_string + &LIBRARY_EXTENSION.to_string()
+		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
 	}
 
 	#[test]

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -1,45 +1,20 @@
+mod library_tests;
+use library_tests::generate_test_path;
+use library_tests::remove_test_path;
 
 #[cfg(test)]
 mod tests
 {
 	use ospl::Library;
-	use ospl::LIBRARY_EXTENSION;
 	use ospl::Error;
-	//use ospl::photo::Photo;
 
 	#[cfg(target_os = "linux")]
 	use std::fs;
-	use rand::{thread_rng, Rng};
-	use rand::distributions::Alphanumeric;
-
-	//use rusqlite::{Connection};
-
-	static TEST_DIR: &str = env!("CARGO_TARGET_TMPDIR");
-
-	fn remove_test_path(path: String)
-	{
-		println!("removing test dir");
-		match std::fs::remove_dir_all(path)
-		{
-			Ok(_) => {},
-			Err(e) => {println!("{:?}", e)}
-		}
-	}
-
-	fn generate_test_path() -> String
-	{
-		let rand_string: String = thread_rng()
-			.sample_iter(&Alphanumeric)
-			.take(30)
-			.map(char::from)
-			.collect();
-		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
-	}
 
 	#[test]
 	fn import_single_photo()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 
 		match library.import_photo("tests/files/test_photo_light.jpg")
@@ -50,55 +25,55 @@ mod tests
 		let p = library.get_photo_from_id(1);
 		println!("imported photo: {:#?}", p);
 		let filename = p.unwrap().get_filename();
-		let photo_path = path.clone() + "/pictures/" + &filename;
-		let thumb_path = path.clone() + "/thumbnails/" + &filename;
-		println!("FULL_PATH: {}", photo_path.clone());
+		let photo_path = path.join("pictures").join(&filename);
+		let thumb_path = path.join("thumbnails").join(&filename);
+		println!("FULL_PATH: {:?}", photo_path);
 		assert!(std::path::Path::new(&photo_path).exists());
 		assert!(std::path::Path::new(&thumb_path).exists());
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn import_single_photo_on_folder()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		assert_eq!(library.import_photo("tests/files/test_folder/").err().unwrap(), Error::IsADirectory);
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn import_photo_file_not_an_image()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		assert_eq!(library.import_photo("tests/files/not_an_image.odt").err().unwrap(), Error::NotAnImage);
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn import_photo_file_not_valid()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		assert_eq!(library.import_photo("tests/files/not_a_valid_file.png").err().unwrap(), Error::NotAnImage);
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	fn import_photo_no_string()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		assert_eq!(library.import_photo("").err().unwrap(), Error::NotFound);
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
 	#[cfg(target_os = "linux")]
 	fn import_photo_permission_denied()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let library = Library::create(&path).unwrap();
 		#[cfg(all(unix))]
 		{
@@ -112,6 +87,6 @@ mod tests
 			reset_perms.arg("777").arg("tests/files/test_photo_no_permissions.jpg");
 			reset_perms.status().expect("process failed to execute");
 		}
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 }

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -33,7 +33,7 @@ mod tests
 			.take(30)
 			.map(char::from)
 			.collect();
-		TEST_DIR.to_string() + &rand_string + &LIBRARY_EXTENSION.to_string()
+		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
 	}
 
 	#[test]

--- a/tests/library_tests.rs
+++ b/tests/library_tests.rs
@@ -32,7 +32,7 @@ mod tests
 			.take(30)
 			.map(char::from)
 			.collect();
-		TEST_DIR.to_string() + &rand_string + &LIBRARY_EXTENSION.to_string()
+		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
 	}
 
 	fn check_table_presence(name: &str, db: &str) -> bool

--- a/tests/library_tests.rs
+++ b/tests/library_tests.rs
@@ -55,6 +55,7 @@ mod tests
 	fn library_path()
 	{
 		let path = generate_test_path();
+		println!("creating library at {}", path);
 		let _library = match Library::create(&path)
 		{
 			Ok(lib) =>

--- a/tests/library_tests.rs
+++ b/tests/library_tests.rs
@@ -1,41 +1,43 @@
+static TEST_DIR: &str = env!("CARGO_TARGET_TMPDIR");
+
+use std::path::{Path, PathBuf};
+use rand::{thread_rng, Rng};
+use rand::distributions::Alphanumeric;
+
+use ospl::LIBRARY_EXTENSION;
+
+pub fn generate_test_path() -> PathBuf
+{
+	let rand_string: String = thread_rng()
+		.sample_iter(&Alphanumeric)
+		.take(30)
+		.map(char::from)
+		.collect();
+	Path::new(TEST_DIR).join(rand_string + LIBRARY_EXTENSION).to_path_buf()
+}
+
+pub fn remove_test_path<P: AsRef<Path>>(path: P)
+{
+	println!("removing test dir");
+	match std::fs::remove_dir_all(path)
+	{
+		Ok(_) => {},
+		Err(e) => {println!("{:?}", e)}
+	}
+}
+
 
 #[cfg(test)]
 mod tests
 {
 	use ospl::Library;
 	use ospl::*;
-	use ospl::LIBRARY_EXTENSION;
-	
-	use rand::{thread_rng, Rng};
-	use rand::distributions::Alphanumeric;
-
 	use rusqlite::{Connection};
-
 
 	static TEST_DIR: &str = env!("CARGO_TARGET_TMPDIR");
 	static LIBRARY_CREATE_ERROR: &str = "error creating library";
 
-	fn remove_test_path(path: String)
-	{
-		println!("removing test dir");
-		match std::fs::remove_dir_all(path)
-		{
-			Ok(_) => {},
-			Err(e) => {println!("{:?}", e)}
-		}
-	}
-
-	fn generate_test_path() -> String
-	{
-		let rand_string: String = thread_rng()
-			.sample_iter(&Alphanumeric)
-			.take(30)
-			.map(char::from)
-			.collect();
-		TEST_DIR.to_string() + "/" + &rand_string + &LIBRARY_EXTENSION.to_string()
-	}
-
-	fn check_table_presence(name: &str, db: &str) -> bool
+	fn check_table_presence<P: AsRef<std::path::Path>>(name: &str, db: P) -> bool
 	{
 		let conn = Connection::open(db).unwrap();
 		let mut conn = conn.prepare(
@@ -54,41 +56,41 @@ mod tests
 	#[test]
 	fn library_path()
 	{
-		let path = generate_test_path();
-		println!("creating library at {}", path);
+		let path = super::generate_test_path();
+		println!("creating library at {:?}", path);
 		let _library = match Library::create(&path)
 		{
 			Ok(lib) =>
 			{
-				println!("check if {} == {}", lib.get_path().to_string_lossy(), path);
-				assert_eq!(lib.get_path().to_string_lossy(), path);
+				println!("check if {:?} == {:?}", lib.get_path(), path);
+				assert_eq!(lib.get_path(), path);
 			},
 			Err(e) => {panic!("{}: {:?}", LIBRARY_CREATE_ERROR, e)},
 		};
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 	#[test]
 	fn library_database()
 	{
-		let path = generate_test_path();
-		let db_path = path.clone() + "/database.db";
+		let path = super::generate_test_path();
+		let db_path = path.join("database.db");
 
 		let _library = match Library::create(&path)
 		{
 			Ok(_lib) =>
 			{
-				println!("checking if database has been created at {}", &db_path);
+				println!("checking if database has been created at {:?}", &db_path);
 				assert!(std::path::Path::new(&db_path).exists());
 			},
 			Err(e) => panic!("{}: {:?}", LIBRARY_CREATE_ERROR, e),
 		};
-		assert!(check_table_presence("settings", &db_path));
+		assert!(check_table_presence("settings", &db_path.to_str().unwrap()));
 		assert!(check_table_presence("photos", &db_path));
 		assert!(check_table_presence("collections", &db_path));
 		assert!(check_table_presence("tags", &db_path));
 		assert!(check_table_presence("photos_tags_map", &db_path));
 		assert!(check_table_presence("albums", &db_path));
-		remove_test_path(path);
+		super::remove_test_path(path);
 	}
 
 	#[test]
@@ -107,12 +109,12 @@ mod tests
 	#[test]
 	fn library_init()
 	{
-		let path = generate_test_path();
+		let path = super::generate_test_path();
 		let _library = Library::create(&path).unwrap();
 
-		assert!(std::path::Path::new(&(path.clone() + "/thumbnails")).exists());
-		assert!(std::path::Path::new(&(path.clone() + "/pictures")).exists());
-		assert!(std::path::Path::new(&(path.clone() + "/collections")).exists());
-		remove_test_path(path);
+		assert!(std::path::Path::new(&(path.join("thumbnails"))).exists());
+		assert!(std::path::Path::new(&(path.join("pictures"))).exists());
+		assert!(std::path::Path::new(&(path.join("collections"))).exists());
+		super::remove_test_path(path);
 	}
 }


### PR DESCRIPTION
Refactoring how the database module works. Any function should
have its own Connection, in the future it is easier to create transactions
or multiple threads that call these functions.

closes #56 
closes #57 
closes #32 

- The paths in the tests are using Path
- The generate_test_path function is removed from other files and included from anywhere else
- The getters are renamed using recommendations (field name with no 'get')